### PR TITLE
Make sure binary response is buffered correctly

### DIFF
--- a/tasks/download.js
+++ b/tasks/download.js
@@ -45,7 +45,12 @@ module.exports = function(grunt) {
 
 		var project_url = options.url + '/api/projects/' + options.slug;
 
-		request( project_url, function(error, response, body) {
+		var options = {
+			url: project_url,
+			encoding: null
+		}
+
+		request( options, function(error, response, body) {
 			if ( ! error && response.statusCode === 200 ) {
 				var data = JSON.parse( body );
 				var set, index, format, url;


### PR DESCRIPTION
Fixes https://github.com/Yoast/google-analytics-for-wordpress/issues/305

We had a problem where the translations would no longer be loaded when downloaded through the `glotpress_download` grunt task. We noticed that we didn't have this problem when downloading the MO files manually from GlotPress, so we figured it might be an encoding issue.

After some debugging together with @tacoverdo, I think we've finally found the solution.

We found that the MO file was written away [here](https://glotpress.trac.wordpress.org/browser/trunk/pomo/mo.php#L69) in an "[unsigned long (always 32 bit, little endian byte order)](http://php.net/manual/en/function.pack.php)" binary format.

We also found that no encoding options were passed into the `request` function that downloads the MO file, resulting in a `utf8` string encoding (as is the [default](https://github.com/request/request#requestoptions-callback)).

When looking at the Node documentation, I could see there is also a `binary` encoding available, which has been [deprecated in favour of Buffer objects](http://nodejs.org/api/buffer.html#buffer_buffer). 

In order to make sure the response is correctly buffered and not converted into a string, we needed to [set the encoding to `null`](https://stackoverflow.com/questions/14145533/how-can-i-buffer-a-http-response-using-the-request-module#answer-14145853). After doing so, our translations were loaded correctly again. :smile_cat: 