### PR TITLE
Allow distinguishing slugs in the filename

### DIFF
--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -109,7 +109,9 @@ module.exports = {
 			textdomain: options.textdomain,
 			locale: set.locale,
 			wp_locale: set.wp_locale,
-			format: format
+			slug: set.slug,
+			slugSuffix: ( set.slug === "default" ) ? "" : "-" + set.slug,
+			format: format,
 		};
 
 		if ( ! info.wp_locale ) {


### PR DESCRIPTION
We were having a weird issue where the formal version would overwrite the informal version for dutch seemingly at random. This was a race condition. With this change, you can add `%slug%` or `%slugSuffix%` to your filename to distinguish between formal and informal versions.