### PR TITLE
Add batchSize option to limit concurrent downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ Default value: `{translation_sets: false, minimum_percentage: 30, waiting_string
 You can filter which files you want to have. By default it only checks the minimum percentage translation sets need to be translated.
 The other parameters still need to be implemented.
 
+#### options.batchSize
+Type: `Number`
+Default value: `-1`
+
+You can limit the amount of files being downloaded at one time. Set to `-1` for no limit.
+
 
 ### Usage Examples
 

--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -21,7 +21,7 @@ module.exports = {
 				maximum_percentage: 100,
 				waiting_strings: false
 			},
-			batchSize: 5,
+			batchSize: -1,
 		});
 
 		if ( ! options.url || ! options.slug ) {

--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -1,17 +1,10 @@
 'use strict';
 
-var request = require( 'request' );
-var grunt = require( 'grunt' );
-
-var api_url;
-var current_requests = 0;
-var callback;
+const request = require( 'request-promise-native' );
+const grunt = require( 'grunt' );
 
 module.exports = {
-
-	download_translations : function( options, callback ) {
-		this.callback = callback
-
+	download_translations : async function( options ) {
 		options = this.merge_defaults( options, {
 			domainPath: 'languages',
 			url: false,
@@ -27,12 +20,12 @@ module.exports = {
 				minimum_percentage: 30,
 				maximum_percentage: 100,
 				waiting_strings: false
-			}
+			},
+			batchSize: 5,
 		});
 
 		if ( ! options.url || ! options.slug ) {
-			this.callback( false, "All required options aren't filled in." );
-			return;
+			return { success: false, message: "All required options aren't filled in." };
 		}
 
 		options.url        = this.strip_trailing_slash( options.url );
@@ -42,9 +35,8 @@ module.exports = {
 			options.textdomain = options.slug;
 		}
 
-		api_url = options.url + '/api/projects/' + options.slug;
-
-		this.get_project_data( api_url, options );
+		const success = await this.get_project_data( options );
+		return { success };
 	},
 
 	merge_defaults : function( options, defaults ) {
@@ -63,48 +55,52 @@ module.exports = {
 		return str;
 	},
 
-	get_project_data : function( api_url, options ) {
-		var self = this;
+	get_api_url : function( options ) {
+		return options.url + '/api/projects/' + options.slug;
+	},
 
-		request( api_url, function(error, response, body) {
-			if ( ! error && response.statusCode === 200 ) {
-				var data = JSON.parse( body );
-				var set, index, format;
+	get_project_data : async function( options ) {
+		try {
+			const data = await request( this.get_api_url( options ), { json: true } );
+			const translation_sets = data.translation_sets.filter( set => {
+				const percent_translated = parseInt( set.percent_translated );
 
-				for ( index in data.translation_sets ) {
-					set = data.translation_sets[ index ];
+				return set.current_count > 0 &&
+					percent_translated >= options.filter.minimum_percentage &&
+					percent_translated <= options.filter.maximum_percentage;
+			} );
 
-					if ( 0 === set.current_count ) {
-						continue;
-					}
+			let downloads = [];
+			for ( const set of translation_sets ) {
+				for ( const format of options.formats ) {
+					const download = this.download_translations_from_set( set, format, options );
+					downloads.push( download );
 
-					if ( options.filter.minimum_percentage > parseInt( set.percent_translated ) ) {
-						continue;
-					}
-
-					if ( options.filter.maximum_percentage < parseInt( set.percent_translated ) ) {
-						continue;
-					}
-
-					for ( format in options.formats ) {
-						self.download_translations_from_set( set, options.formats[ format ], options );
+					if ( options.batchSize !== -1 && downloads.length >= options.batchSize ) {
+						await Promise.all( downloads );
+						downloads = [];
 					}
 				}
 			}
-			else {
-				self.callback(false);
-			}
-		});
+
+			await Promise.all( downloads );
+
+			return true;
+		} catch( error ) {
+			console.error( "An error occured downloading project data.", error );
+
+			return false;
+		}
 	},
 
-	download_translations_from_set : function( set, format, options ) {
-		var url = api_url + '/' + set.locale + '/' + set.slug + '/export-translations?format=' + format;
+	download_translations_from_set : async function( set, format, options ) {
+		let url = this.get_api_url( options ) + '/' + set.locale + '/' + set.slug + '/export-translations?format=' + format;
 
 		if ( options.filter.waiting_strings ) {
 			url += '&filters[status]=all';
 		}
 
-		var info = {
+		const info = {
 			domainPath: options.domainPath,
 			textdomain: options.textdomain,
 			locale: set.locale,
@@ -122,7 +118,7 @@ module.exports = {
 			}
 		}
 
-		this.download_file( url, this.build_filename( options.file_format, info ) );
+		return this.download_file( url, this.build_filename( options.file_format, info ) );
 	},
 
 	build_filename : function( format, data ) {
@@ -131,27 +127,16 @@ module.exports = {
 		});
 	},
 
-	download_file : function( url, file ) {
-		var self = this;
+	download_file : async function( url, file ) {
+		try {
+			const body = await request( { url, encoding: null } );
+			grunt.file.write( process.cwd() + '/' + file, body );
 
-		current_requests++;
+			return true;
+		} catch( error ) {
+			console.error( "An error occured downloading translation files.", error );
 
-		var request_options = {
-			url: url,
-			encoding: null
-		};
-
-		request( request_options, function(error, response, body) {
-			if ( ! error && response.statusCode === 200 ) {
-				var feedback = grunt.file.write( process.cwd() + '/' + file, body );
-			}
-
-			current_requests--;
-
-			if ( current_requests === 0 ) {
-				self.callback(true);
-			}
-		});
+			return false;
+		}
 	}
-
-}
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "grunt-glotpress",
 	"description": "Gets translations from a GlotPress installation",
-	"version": "0.2.2",
+	"version": "0.3.0",
 	"homepage": "https://github.com/markoheijnen/grunt-glotpress",
 	"author": {
 		"name": "Marko Heijnen",
@@ -37,7 +37,8 @@
 		"grunt": ">=1.0.1"
 	},
 	"dependencies": {
-		"request": "^2.79.0"
+		"request": "^2.88.0",
+		"request-promise-native": "^1.0.7"
 	},
 	"keywords": [
 		"gruntplugin"

--- a/tasks/download.js
+++ b/tasks/download.js
@@ -10,28 +10,26 @@
 
 
 module.exports = function(grunt) {
-	var downloader = require( '../lib/downloader' ),
-		path = require( 'path' );
-
-	var is_done;
+	const downloader = require( '../lib/downloader' );
+	const path = require( 'path' );
 
 	grunt.registerMultiTask('glotpress_download', 'Gets translations from a GlotPress installation', function() {
-		is_done = this.async();
+		const is_done = this.async();
 
 		// Merge task-specific and/or target-specific options with these defaults.
-		var options = this.options({
-			cwd: process.cwd()
+		const options = this.options({
+			cwd: process.cwd(),
 		});
 
 		options.cwd = path.resolve( process.cwd(), options.cwd );
 		grunt.file.setBase( options.cwd );
 
-		downloader.download_translations( options, function(success, message) {
+		downloader.download_translations( options ).then( function( { success, message } ) {
 			if ( message && ! success ) {
-				grunt.fail.report(message);
+				grunt.fail.report( message );
 			}
 
-			is_done(success);
+			is_done( success );
 		} );
 	});
 

--- a/test/glotpress_test.js
+++ b/test/glotpress_test.js
@@ -1,8 +1,6 @@
 'use strict';
 
-var 
-	glotpress_downloader = require('../lib/downloader');
-;
+const glotpress_downloader = require('../lib/downloader');
 
 exports.test_glotpress_download = {
 	setUp: function(callback) {
@@ -16,23 +14,23 @@ exports.test_glotpress_download = {
 
 
 	download_translations_test_empty_options: function(test) {
-		var options = {};
+		const options = {};
 
-		glotpress_downloader.download_translations( options, function(success, message) {
-			test.equal( success, false);
+		glotpress_downloader.download_translations( options ).then( function( { success, message } ) {
+			test.equal( success, false );
 			test.done();
 		} );
 	},
 
 	download_translations_test_callback: function(test) {
-		var options = {
+		const options = {
 			domainPath: 'tmp',
-			url: 'http://wp-translate.org',
-			slug: 'tabify-edit-screen',
-			textdomain: 'tabify-edit-screen',
+			url: 'http://translate.yoast.com',
+			slug: 'wordpress-seo-premium',
+			textdomain: 'wordpress-seo-premium',
 		};
 
-		glotpress_downloader.download_translations( options, function(success, message) {
+		glotpress_downloader.download_translations( options ).then( function( { success, message } ) {
 			test.equal( success, true);
 			test.done();
 		} );
@@ -40,8 +38,8 @@ exports.test_glotpress_download = {
 
 
 	merge_defaults_test_default: function(test) {
-		var defaults = { test: '1' }
-		var options  = glotpress_downloader.merge_defaults( {}, defaults );
+		const defaults = { test: '1' };
+		const options  = glotpress_downloader.merge_defaults( {}, defaults );
 
 		test.equal( options.test, '1' );
 
@@ -49,8 +47,8 @@ exports.test_glotpress_download = {
 	},
 
 	merge_defaults_test_overwrite: function(test) {
-		var defaults = { test: '1' }
-		var options  = glotpress_downloader.merge_defaults( { test: '2' }, defaults );
+		const defaults = { test: '1' };
+		const options  = glotpress_downloader.merge_defaults( { test: '2' }, defaults );
 
 		test.equal( options.test, '2' );
 

--- a/test/glotpress_test.js
+++ b/test/glotpress_test.js
@@ -25,9 +25,9 @@ exports.test_glotpress_download = {
 	download_translations_test_callback: function(test) {
 		const options = {
 			domainPath: 'tmp',
-			url: 'http://translate.yoast.com',
-			slug: 'wordpress-seo-premium',
-			textdomain: 'wordpress-seo-premium',
+			url: 'http://wp-translate.org',
+			slug: 'tabify-edit-screen',
+			textdomain: 'tabify-edit-screen',
 		};
 
 		glotpress_downloader.download_translations( options ).then( function( { success, message } ) {


### PR DESCRIPTION
Recently we ran into an issue where our GlotPress installation would suffer whenever this task was ran as it attempts to download all files simultaneously, causing a large amount of executions on what is, apparently, a rather expensive operation.

To fix this I've updated the code to support a new batchSize option which limits the number of concurrent downloads accordingly. The default of `-1` retains the current behaviour of downloading all files concurrently.

In order to keep code readable I've used `async` and `await` to provide this feature along with several other modern JS features  such as arrow functions, `const` and `let`. Not sure what Node version this package is targeting so it may not be desirable to merge this feature as-is. Did want to share it in any case should anyone else find it useful.